### PR TITLE
Add Lock to Scraping Scheduler

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,36 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: | 
+            ghcr.io/${{ github.repository_owner }}/bdo-api:latest
+            ghcr.io/${{ github.repository_owner }}/bdo-api:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:21-latest AS builder
+FROM azul/zulu-openjdk-alpine:21-latest AS builder
 
 COPY .. /app
 WORKDIR /app
@@ -7,7 +7,7 @@ RUN chmod 755 ./**
 
 RUN ["./gradlew", "clean", "build", "-x", "test"]
 
-FROM builder AS runner
+FROM azul/zulu-openjdk-alpine:21-latest AS runner
 
 RUN mkdir -p /arsha/config
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To avoid putting an unnecessary load on PA's infrastructure, you can use this wr
 
 ### How do I use it?
 
-You can use the public instance at https://dev.api.arsha.io, or you can host your own instance. Documentation on all available
+You can use the public instance at https://api.arsha.io, or you can host your own instance. Documentation on all available
 endpoints is available on [Postman](https://documenter.getpostman.com/view/4028519/2s9Y5YRhp4#674b362e-2a27-4961-ac07-dfb925aee842).
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4028519-0539c251-5838-4d15-94cd-565aa8293137?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D4028519-0539c251-5838-4d15-94cd-565aa8293137%26entityType%3Dcollection%26workspaceId%3D69d535c0-8852-452e-81a7-f8c8584e19f0#?env%5BCONSOLE_NA%5D=W3sia2V5IjoicmVnaW9uIiwidmFsdWUiOiJjb25zb2xlX25hIiwiZW5hYmxlZCI6dHJ1ZX1d)
@@ -31,17 +31,19 @@ that you have Docker installed on your machine. https://docs.docker.com/get-dock
 Ideally you would also have it hosted behind a reverse proxy such as Nginx or Caddy, but this is not a requirement. 
 - [nginx example](nginx/api.example.com)
 
+### Docker Compose
+
 #### Steps:
 ```bash
 git clone https://github.com/guy0090/api.arsha.io.git
 cd api.arsha.io
 
 # Optionally, you can change the port (default: 3000) that the API runs on by editing the exposed port in compose.yaml
-vim compose.yaml
+vi compose.yaml
 
 # Optionally, you can also configure API default properties:
 cp config/application-default.yaml config/application.yaml
-vim config/application.yaml
+vi config/application.yaml
 
 # Build and start container
 docker compose up -d
@@ -52,3 +54,21 @@ docker compose up -d
 git pull
 docker compose up --build api -d
 ```
+
+### Kubernetes
+A minimal Kubernetes deployment is also provided in the [manifests](manifests) directory. 
+- This deployment assumes you have a working Kubernetes cluster and have `cert-manager` and `nginx-ingress` installed and configured.
+
+### Steps:
+```bash
+git clone https://github.com/guy0090/api.arsha.io.git
+vi manifest/api.yaml # You'll have to adjust some values such as domain, ingress class, etc.
+kubectl apply -f api.yaml
+```
+
+### Updating:
+```bash
+# If you didn't change the image used, you can trigger a rollout to update the deployment to the newest tag
+kubectl rollout restart deployment/api -n arsha
+```
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
 	java
-	id("org.springframework.boot") version "3.1.4"
-	id("io.spring.dependency-management") version "1.1.3"
+	id("org.springframework.boot") version "3.1.6"
+	id("io.spring.dependency-management") version "1.1.4"
 }
 
 group = "io.arsha"
@@ -27,8 +27,6 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
-	implementation("org.springframework.boot:spring-boot-starter-websocket")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.apache.commons:commons-lang3:3.12.0")
 	implementation("jakarta.inject:jakarta.inject-api:2.0.1.MR")

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       arsha:
         aliases:
           - api.service.arsha
+          - api
     links:
       - redis
       # - redis-test
@@ -27,6 +28,7 @@ services:
       arsha:
         aliases:
           - redis.service.arsha
+          - redis
     volumes:
       - redis-data:/data
 #  redis-test:

--- a/config/application-default.yaml
+++ b/config/application-default.yaml
@@ -19,7 +19,7 @@ docs: "https://documenter.getpostman.com/view/4028519/2s9Y5YRhp4#674b362e-2a27-4
 # Redis config
 cache:
   redis:
-    host: redis.service.arsha
+    host: redis
     port: 6379
   ttl: 30
 

--- a/manifests/api.yaml
+++ b/manifests/api.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arsha
+--- # API Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: arsha
+  labels:
+    name: api
+spec:
+  selector:
+    matchLabels:
+      name: api
+  replicas: 4 # Replace with your desired number of replicas
+  template:
+    metadata:
+      labels:
+        name: api
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/guy0090/bdo-api:latest
+          ports:
+            - containerPort: 3000
+          imagePullPolicy: Always
+--- # Redis Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: arsha
+  labels:
+    name: redis
+spec:
+  selector:
+    matchLabels:
+      name: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:latest
+          ports:
+            - containerPort: 6379
+--- # API Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  labels:
+    name: api
+  namespace: arsha
+spec:
+  ports:
+    - port: 3000
+      protocol: TCP
+  selector:
+    name: api
+--- # Redis Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    name: redis
+  namespace: arsha
+spec:
+  ports:
+    - port: 6379
+      protocol: TCP
+  selector:
+    name: redis
+--- # API Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: api-ingress
+  namespace: arsha
+  annotations:
+    cert-manager.io/cluster-issuer: lets-encrypt # Replace with your cluster issuer
+spec:
+  ingressClassName: nginx # Replace with your ingress class
+  tls:
+    - hosts:
+        - api.arsha.io # Replace with your domain
+      secretName: api-secret
+  rules:
+    - host: api.arsha.io # Replace with your domain
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 3000

--- a/src/main/java/io/arsha/api/Application.java
+++ b/src/main/java/io/arsha/api/Application.java
@@ -1,12 +1,16 @@
 package io.arsha.api;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.net.InetAddress;
 
 @EnableAsync
 @EnableScheduling
@@ -16,6 +20,18 @@ public class Application {
 
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
+	}
+
+	@Bean
+	public String hostName() {
+		var hostName = System.getenv("HOSTNAME");
+		if (hostName != null && !hostName.isBlank()) return hostName;
+
+		try {
+			return InetAddress.getLocalHost().getHostName();
+		} catch (Exception e) {
+			return "host_" + RandomStringUtils.randomAlphabetic(8);
+		}
 	}
 
 }

--- a/src/main/java/io/arsha/api/config/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/io/arsha/api/config/exceptions/GlobalExceptionHandler.java
@@ -85,11 +85,12 @@ public class GlobalExceptionHandler {
         logger.error(message);
     }
 
-    record ExceptionResponse(Integer status, String message, String path, String timestamp, UUID id, Integer code) {
+    public record ExceptionResponse(Integer status, String message, String path, String timestamp, UUID id, Integer code, String host) {
         public static ExceptionResponse fromAbstractException(AbstractException ex, HttpServletRequest req) {
             var timestamp = OffsetDateTime.now().format(DateTimeFormatter.ISO_INSTANT);
+            var host = System.getenv("HOSTNAME");
             return new ExceptionResponse(ex.getStatus(), ex.getMessage(), req.getRequestURI(),
-                    timestamp, UUID.randomUUID(), ex.getExceptionCode().getCode());
+                    timestamp, UUID.randomUUID(), ex.getExceptionCode().getCode(), host);
         }
 
         public static ExceptionResponse fromException(Exception ex, HttpServletRequest req) {
@@ -132,9 +133,10 @@ public class GlobalExceptionHandler {
                 }
             }
 
+            var host = System.getenv("HOSTNAME");
             var timestamp = OffsetDateTime.now().format(DateTimeFormatter.ISO_INSTANT);
             return new ExceptionResponse(status, errorMsg, req.getRequestURI(),
-                    timestamp, UUID.randomUUID(), 0);
+                    timestamp, UUID.randomUUID(), 0, host);
         }
     }
 }

--- a/src/main/java/io/arsha/api/data/market/items/GetWorldMarketSearchList.java
+++ b/src/main/java/io/arsha/api/data/market/items/GetWorldMarketSearchList.java
@@ -22,8 +22,8 @@ public class GetWorldMarketSearchList extends ParsedItems<ParsedList> {
     @EqualsAndHashCode(callSuper = true)
     public static class Item extends ParsedList.ParsedItem {
         Long currentStock;
-        Long totalTrades;
         Long basePrice;
+        Long totalTrades;
 
         Item(String name, String item) {
             String[] attributes = item.split("-");
@@ -31,8 +31,8 @@ public class GetWorldMarketSearchList extends ParsedItems<ParsedList> {
             setName(name);
             setId(Long.valueOf(attributes[0]));
             currentStock = Long.valueOf(attributes[1]);
-            totalTrades = Long.valueOf(attributes[2]);
-            basePrice = Long.valueOf(attributes[3]);
+            basePrice = Long.valueOf(attributes[2]);
+            totalTrades = Long.valueOf(attributes[3]);
         }
     }
 }

--- a/src/main/java/io/arsha/api/services/ScraperDataRedisService.java
+++ b/src/main/java/io/arsha/api/services/ScraperDataRedisService.java
@@ -21,9 +21,22 @@ import java.util.stream.Collectors;
 public class ScraperDataRedisService {
 
     static final String LAST_SCRAPE_TIME_KEY = "lastScrapedTime";
+    static final String LOCK_KEY = "scraperLock";
 
     private final RedisTemplate<String, ScrapedItem> redisTemplate;
     private final RedisTemplate<String, String> redisStringTemplate;
+
+    public void setLock(String lockOwner) {
+        redisStringTemplate.opsForValue().set(LOCK_KEY, lockOwner);
+    }
+
+    public void releaseLock() {
+        redisStringTemplate.delete(LOCK_KEY);
+    }
+
+    public Optional<String> getLockOwner() {
+        return Optional.ofNullable(redisStringTemplate.opsForValue().get(LOCK_KEY));
+    }
 
     public void saveLastScrapedTime(String locale) {
         redisStringTemplate.<String, String>opsForHash().put(LAST_SCRAPE_TIME_KEY, locale, String.valueOf(System.currentTimeMillis()));
@@ -79,5 +92,5 @@ public class ScraperDataRedisService {
     public List<ScrapedItem> getAll(String locale) {
         return redisTemplate.<String, ScrapedItem>opsForHash().values(locale);
     }
-    
+
 }

--- a/src/main/java/io/arsha/api/services/ScraperService.java
+++ b/src/main/java/io/arsha/api/services/ScraperService.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor(onConstructor = @__(@Inject))
 public class ScraperService {
 
-    private final String hostName = System.getenv("HOSTNAME");
+    private final String hostName;
     private final RestTemplate httpClient;
     private final ScraperDataRedisService redisService;
     private final CodexConfigurationService codexConfigurationService;


### PR DESCRIPTION
Adds a locking mechanism to the automatic scraping job. Primarily aimed at allowing multiple concurrent instances to run in k8s without concurrently starting a scrape run.

Manifests coming soontm