### PR TITLE
Fix console region hostnames (stale hosts behind the 'blocked by Imperva' 500s)

### DIFF
--- a/config/application-default.yaml
+++ b/config/application-default.yaml
@@ -89,10 +89,10 @@ marketplace:
     url: "trade.global-lab.playblackdesert.com"
   console.na:
     enabled: true
-    url: "na-trade.console.playblackdesert.com"
+    url: "console-na-trade.blackdesert.pearlabyss.com"
   console.eu:
     enabled: true
-    url: "eu-trade.console.playblackdesert.com"
+    url: "console-eu-trade.blackdesert.pearlabyss.com"
   console.asia:
     enabled: true
-    url: "asia-trade.console.playblackdesert.com"
+    url: "console-asia-trade.blackdesert.pearlabyss.com"

--- a/config/application-dev.yaml
+++ b/config/application-dev.yaml
@@ -89,10 +89,10 @@ marketplace:
     url: "trade.global-lab.playblackdesert.com"
   console.na:
     enabled: true
-    url: "na-trade.console.playblackdesert.com"
+    url: "console-na-trade.blackdesert.pearlabyss.com"
   console.eu:
     enabled: true
-    url: "eu-trade.console.playblackdesert.com"
+    url: "console-eu-trade.blackdesert.pearlabyss.com"
   console.asia:
     enabled: true
-    url: "asia-trade.console.playblackdesert.com"
+    url: "console-asia-trade.blackdesert.pearlabyss.com"

--- a/src/main/java/io/arsha/api/data/market/common/MarketConstants.java
+++ b/src/main/java/io/arsha/api/data/market/common/MarketConstants.java
@@ -21,7 +21,7 @@ public final class MarketConstants {
     public static final String TW_URL = "trade.tw.playblackdesert.com";
     public static final String SA_URL = "trade.sa.playblackdesert.com";
     public static final String GL_URL = "trade.global-lab.playblackdesert.com";
-    public static final String CONSOLE_NA_URL = "na-trade.console.playblackdesert.com";
-    public static final String CONSOLE_EU_URL = "eu-trade.console.playblackdesert.com";
-    public static final String CONSOLE_ASIA_URL = "asia-trade.console.playblackdesert.com";
+    public static final String CONSOLE_NA_URL = "console-na-trade.blackdesert.pearlabyss.com";
+    public static final String CONSOLE_EU_URL = "console-eu-trade.blackdesert.pearlabyss.com";
+    public static final String CONSOLE_ASIA_URL = "console-asia-trade.blackdesert.pearlabyss.com";
 }


### PR DESCRIPTION
## Problem

All three console regions (`console_na`, `console_eu`, `console_asia`) currently fail with:

```
HTTP 500 {"message":"One or more requests returned invalid data (probably blocked by Imperva). Try again later."}
```

The root cause is not (only) Imperva bot-blocking: the configured console hostnames (`{na,eu,asia}-trade.console.playblackdesert.com`) no longer serve the TradeMarket API. They now redirect to the Pearl Abyss account/login page ("Log In to Pearl Abyss", served with `account.pearlabyss.com` cookies behind Imperva). Since the wrapper receives HTML, `MarketRequestService#huffmanDecode` maps it to the Imperva error. Reproduced from a residential IP, so it is not IP-reputation blocking.

## Fix

Point the console regions at the hosts the console Web Central Market actually uses today, discovered via the old hosts' own browser redirect chain (`asia-trade.console.playblackdesert.com/` → `console-asia-trade.blackdesert.pearlabyss.com/Error?param=Browser`):

| region | old (broken) | new (working, 2026-07) |
|---|---|---|
| console_na | `na-trade.console.playblackdesert.com` | `console-na-trade.blackdesert.pearlabyss.com` |
| console_eu | `eu-trade.console.playblackdesert.com` | `console-eu-trade.blackdesert.pearlabyss.com` |
| console_asia | `asia-trade.console.playblackdesert.com` | `console-asia-trade.blackdesert.pearlabyss.com` |

Same protocol as PC (`POST /TradeMarket/{endpoint}`, `User-Agent: BlackDesert`, `{"keyType":0,...}` body), no authentication required:

```
POST https://console-asia-trade.blackdesert.pearlabyss.com/TradeMarket/GetWorldMarketSearchList
{"keyType":0,"searchResult":"5301,6656,9206"}
→ {"resultCode":0,"resultMsg":"5301-0-10000-87553637|..."}
```

## Verification

- `GetWorldMarketSearchList`, `GetWorldMarketSubList`, and `GetBiddingInfoList` all return valid JSON on all three new hosts.
- Data is genuinely console-specific: spot-checked 7 items against prices read directly off the in-game console (PS5, Asia) Central Market — all 7 matched exactly, including items whose console price differs ~50% from PC (e.g. Troll Blood 6220: console 23,100 vs PC SEA 46,600).

## Caveat

Verified from a residential IP only. The new hosts are also fronted by Imperva, so please confirm the public instance's datacenter egress IPs are not challenged before relying on this in production.

## Disclaimer

This investigation and patch were done via vibe coding with Claude (Anthropic's AI assistant) driving the endpoint archaeology, testing, and edits, supervised by a human console player who verified prices in-game. The change itself is only three hostname strings, but please review with that context in mind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
